### PR TITLE
Split API and worker deployment workflow by APP_MODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,42 @@ The app loads environment variables from `.env` via `github.com/joho/godotenv`.
 ## Run full stack (Docker Compose)
 
 ```bash
-docker compose up --build
+docker compose --profile demo up --build
 ```
 
-Services:
+Demo service topology:
+- `app` (`APP_MODE=all`): API + worker in one process (demo profile)
+- `postgres`
+- `rabbitmq`
+
+## Run split API + worker processes (recommended)
+
+```bash
+docker compose up --build api worker postgres rabbitmq
+```
+
+Split service topology:
+- `api` (`APP_MODE=api`): serves HTTP (`/healthz`, ticket create/read)
+- `worker` (`APP_MODE=worker`): no HTTP listener, queue consumer only
+- shared dependencies: `postgres`, `rabbitmq`
+
+Services and endpoints:
 - API: `http://localhost:18080`
 - PostgreSQL: `localhost:5433` (`postgres` / `postgres`, db: `tickets`)
 - RabbitMQ management UI: `http://localhost:15672` (`guest` / `guest`)
+
+## Process mode matrix
+
+| `APP_MODE` | HTTP server | Queue consumer | Intended usage |
+|---|---|---|---|
+| `all` | yes | yes | local demo / quickstart |
+| `api` | yes (`/healthz` available) | no | independently scale API replicas |
+| `worker` | no | yes | independently scale async processors |
+
+Graceful shutdown behavior (SIGTERM/SIGINT):
+- `api`: HTTP server drains and exits within `SHUTDOWN_TIMEOUT_SECONDS`.
+- `worker`: consumer loop exits on context cancellation within `SHUTDOWN_TIMEOUT_SECONDS`.
+- `all`: both components are drained before process exit.
 
 ## API usage
 
@@ -94,6 +123,11 @@ Health check:
 curl -sS http://localhost:18080/healthz
 ```
 
+Readiness expectations by mode:
+- `api`: ready when `/healthz` returns `200 {"status":"ok"}`.
+- `worker`: ready when logs show `worker started`; there is no HTTP readiness endpoint in worker-only mode.
+- `all`: both API health check and worker startup logs should be observed.
+
 ## Generate many tickets (queue load script)
 
 Use the included shell script to generate a burst of tickets and observe queue behavior:
@@ -107,6 +141,51 @@ Options:
 - `-n` total tickets (default `50`)
 - `-c` parallel requests/workers (default `10`)
 - `-p` customer id prefix
+
+## Split-mode validation runbook
+
+1. Start only API and dependencies:
+
+```bash
+docker compose up --build api postgres rabbitmq
+```
+
+2. Create tickets through API; they remain in `queued` state while worker is down:
+
+```bash
+curl -sS -X POST http://localhost:18080/v1/tickets \
+  -H 'Content-Type: application/json' \
+  -d '{"customer_id":"cust_split","subject":"payment timeout","body":"checkout keeps timing out"}'
+```
+
+3. Start worker later and confirm backlog is processed:
+
+```bash
+docker compose up worker
+```
+
+4. Stop worker, enqueue more tickets via API, then restart worker to verify recovery:
+
+```bash
+docker compose stop worker
+docker compose up worker
+```
+
+Scaling recommendation:
+- scale `api` for request throughput.
+- scale `worker` for async processing backlog.
+- keep them independent in production-like deployments.
+
+## Troubleshooting
+
+- API healthy but tickets stay `queued`:
+  - `worker` is down or blocked; check `docker compose logs worker`.
+- Worker running but no tickets processed:
+  - verify `AMQP_QUEUE`, RabbitMQ connectivity, and backlog in management UI (`http://localhost:15672`).
+- Startup retries loop:
+  - confirm `postgres` and `rabbitmq` services are healthy and connection URLs match compose network defaults.
+- `/healthz` unavailable:
+  - ensure process runs in `APP_MODE=api` or `APP_MODE=all` (worker mode has no HTTP server).
 
 ## Environment variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,27 @@
+x-app-common: &app-common
+  build:
+    context: .
+    dockerfile: Dockerfile
+  depends_on:
+    postgres:
+      condition: service_healthy
+    rabbitmq:
+      condition: service_healthy
+  environment: &app-env
+    HTTP_ADDR: ":8080"
+    DATABASE_URL: "postgres://postgres:postgres@postgres:5432/tickets?sslmode=disable"
+    AMQP_URL: "amqp://guest:guest@rabbitmq:5672/"
+    AMQP_QUEUE: "tickets.triage"
+    AMQP_MESSAGE_MAX_RETRIES: "3"
+    AMQP_MESSAGE_RETRY_DELAY_MS: "2000"
+    DB_MAX_RETRIES: "20"
+    DB_RETRY_BACKOFF_SECONDS: "2"
+    AMQP_MAX_RETRIES: "20"
+    AMQP_RETRY_BACKOFF_SECONDS: "2"
+    WORKER_SLEEP_MS: "1200"
+    SHUTDOWN_TIMEOUT_SECONDS: "15"
+  restart: unless-stopped
+
 services:
   postgres:
     image: postgres:16-alpine
@@ -31,31 +55,30 @@ services:
       - rabbitmq_data:/var/lib/rabbitmq
 
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    <<: *app-common
     container_name: rabbitamq-queuecraft
-    depends_on:
-      postgres:
-        condition: service_healthy
-      rabbitmq:
-        condition: service_healthy
+    profiles: ["demo"]
     environment:
-      HTTP_ADDR: ":8080"
+      <<: *app-env
       APP_MODE: "all"
-      DATABASE_URL: "postgres://postgres:postgres@postgres:5432/tickets?sslmode=disable"
-      AMQP_URL: "amqp://guest:guest@rabbitmq:5672/"
-      AMQP_QUEUE: "tickets.triage"
-      AMQP_MESSAGE_MAX_RETRIES: "3"
-      AMQP_MESSAGE_RETRY_DELAY_MS: "2000"
-      DB_MAX_RETRIES: "20"
-      DB_RETRY_BACKOFF_SECONDS: "2"
-      AMQP_MAX_RETRIES: "20"
-      AMQP_RETRY_BACKOFF_SECONDS: "2"
-      WORKER_SLEEP_MS: "1200"
     ports:
       - "18080:8080"
-    restart: unless-stopped
+
+  api:
+    <<: *app-common
+    container_name: rabbitamq-api
+    environment:
+      <<: *app-env
+      APP_MODE: "api"
+    ports:
+      - "18080:8080"
+
+  worker:
+    <<: *app-common
+    container_name: rabbitamq-worker
+    environment:
+      <<: *app-env
+      APP_MODE: "worker"
 
 volumes:
   postgres_data:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 
 	"rabbitamq-queuecraft/internal/config"
@@ -67,41 +68,112 @@ func New(ctx context.Context, cfg config.Config, logger *slog.Logger) (*App, err
 }
 
 func (a *App) Run(ctx context.Context) error {
-	errCh := make(chan error, 2)
+	type componentResult struct {
+		name string
+		err  error
+	}
+
+	componentCount := 0
+	if a.cfg.EnableAPI() {
+		componentCount++
+	}
+	if a.cfg.EnableWorker() {
+		componentCount++
+	}
+
+	if componentCount == 0 {
+		a.logger.Info("no components enabled for selected mode", "mode", a.cfg.Mode)
+		return nil
+	}
+
+	a.logger.Info(
+		"app mode started",
+		"mode",
+		a.cfg.Mode,
+		"api_enabled",
+		a.cfg.EnableAPI(),
+		"worker_enabled",
+		a.cfg.EnableWorker(),
+		"shutdown_timeout",
+		a.cfg.ShutdownTimeout,
+	)
+
+	resultCh := make(chan componentResult, componentCount)
+	var wg sync.WaitGroup
+	startComponent := func(name string, run func() error) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resultCh <- componentResult{name: name, err: run()}
+		}()
+	}
 
 	if a.cfg.EnableWorker() {
-		go func() {
-			errCh <- a.worker.Run(ctx)
-		}()
+		startComponent("worker", func() error {
+			return a.worker.Run(ctx)
+		})
 	}
 
 	if a.cfg.EnableAPI() {
-		go func() {
+		startComponent("api", func() error {
 			a.logger.Info("http server started", "addr", a.cfg.HTTPAddr)
 			if err := a.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-				errCh <- fmt.Errorf("listen and serve: %w", err)
-				return
+				return fmt.Errorf("listen and serve: %w", err)
 			}
-			errCh <- nil
-		}()
+			a.logger.Info("http server stopped")
+			return nil
+		})
 	}
 
-	if !a.cfg.EnableAPI() && !a.cfg.EnableWorker() {
-		return nil
-	}
-
+	remaining := componentCount
+	shutdownStarted := false
 	select {
 	case <-ctx.Done():
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), a.cfg.ShutdownTimeout)
-		defer cancel()
-
-		if a.cfg.EnableAPI() {
-			_ = a.server.Shutdown(shutdownCtx)
-		}
-		return nil
-	case err := <-errCh:
-		return err
+		shutdownStarted = true
+	default:
 	}
+
+	for remaining > 0 {
+		if shutdownStarted {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), a.cfg.ShutdownTimeout)
+			if a.cfg.EnableAPI() {
+				a.logger.Info("initiating graceful shutdown", "mode", a.cfg.Mode)
+				if err := a.server.Shutdown(shutdownCtx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+					cancel()
+					return fmt.Errorf("shutdown http server: %w", err)
+				}
+			}
+
+			waitCh := make(chan struct{})
+			go func() {
+				wg.Wait()
+				close(waitCh)
+			}()
+
+			select {
+			case <-waitCh:
+				cancel()
+				a.logger.Info("graceful shutdown complete", "mode", a.cfg.Mode)
+				return nil
+			case <-shutdownCtx.Done():
+				cancel()
+				return fmt.Errorf("shutdown timeout exceeded after %s", a.cfg.ShutdownTimeout)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			shutdownStarted = true
+		case result := <-resultCh:
+			remaining--
+			if result.err != nil {
+				return fmt.Errorf("%s exited with error: %w", result.name, result.err)
+			}
+		}
+	}
+
+	a.logger.Info("all components stopped", "mode", a.cfg.Mode)
+	return nil
 }
 
 func (a *App) Close() error {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,171 @@
+package app
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"rabbitamq-queuecraft/internal/config"
+	"rabbitamq-queuecraft/internal/worker"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type testConsumer struct {
+	onConsume func(ctx context.Context, queue string) error
+}
+
+func (c *testConsumer) Publish(_ context.Context, _ string, _ []byte) error {
+	return nil
+}
+
+func (c *testConsumer) Consume(ctx context.Context, queue string, _ func(context.Context, []byte) error) error {
+	if c.onConsume != nil {
+		return c.onConsume(ctx, queue)
+	}
+	<-ctx.Done()
+	return nil
+}
+
+func (c *testConsumer) Close() error {
+	return nil
+}
+
+func (c *testConsumer) Retry(_ context.Context, _ amqp.Delivery, _ string, _ error) error {
+	return nil
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestRun_APIMode_ShutsDownGracefully(t *testing.T) {
+	cfg := configForTests("api")
+	cfg.HTTPAddr = "127.0.0.1:0"
+	cfg.ShutdownTimeout = 2 * time.Second
+
+	a := &App{
+		cfg:    cfg,
+		logger: testLogger(),
+		server: &http.Server{Addr: cfg.HTTPAddr, Handler: http.NewServeMux()},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Run(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected graceful shutdown, got error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for api mode shutdown")
+	}
+}
+
+func TestRun_WorkerMode_DoesNotStartAPI(t *testing.T) {
+	cfg := configForTests("worker")
+	cfg.ShutdownTimeout = 300 * time.Millisecond
+
+	var consumeCalls atomic.Int32
+	consumer := &testConsumer{
+		onConsume: func(ctx context.Context, _ string) error {
+			consumeCalls.Add(1)
+			<-ctx.Done()
+			return nil
+		},
+	}
+
+	a := &App{
+		cfg:    cfg,
+		logger: testLogger(),
+		server: nil,
+		worker: &worker.Runner{
+			Consumer: consumer,
+			Queue:    "test.queue",
+			Logger:   testLogger(),
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Run(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected graceful shutdown, got error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for worker mode shutdown")
+	}
+
+	if consumeCalls.Load() != 1 {
+		t.Fatalf("expected worker consume to start once, got %d", consumeCalls.Load())
+	}
+}
+
+func TestRun_WorkerMode_ShutdownTimeoutExceeded(t *testing.T) {
+	cfg := configForTests("worker")
+	cfg.ShutdownTimeout = 50 * time.Millisecond
+
+	consumer := &testConsumer{
+		onConsume: func(_ context.Context, _ string) error {
+			select {}
+		},
+	}
+
+	a := &App{
+		cfg:    cfg,
+		logger: testLogger(),
+		worker: &worker.Runner{
+			Consumer: consumer,
+			Queue:    "test.queue",
+			Logger:   testLogger(),
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Run(ctx)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("expected shutdown timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "shutdown timeout exceeded") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("timed out waiting for shutdown timeout error")
+	}
+}
+
+func configForTests(mode string) config.Config {
+	return config.Config{
+		Mode:            mode,
+		ShutdownTimeout: time.Second,
+	}
+}


### PR DESCRIPTION
## Summary
- add first-class split deployment services in docker compose: `api` (`APP_MODE=api`) and `worker` (`APP_MODE=worker`)
- keep demo `app` service in `all` mode behind the `demo` profile
- harden app lifecycle handling for mode-aware startup and graceful shutdown with bounded timeout behavior
- add mode-specific tests for API-only and worker-only runtime behavior
- expand README with mode matrix, split runbook, readiness expectations, scaling guidance, and troubleshooting

## Validation
- go test ./...
- go build ./cmd/server

Closes #1
